### PR TITLE
Fix python3 list iteration

### DIFF
--- a/acitoolkit/acisession.py
+++ b/acitoolkit/acisession.py
@@ -335,7 +335,7 @@ class Subscriber(threading.Thread):
             num_subscriptions = len(event['subscriptionId'])
             for i in range(0, num_subscriptions):
                 url = None
-                for k, v in self._subscriptions.items():
+                for k, v in list(self._subscriptions.items()):
                     if v == str(event['subscriptionId'][i]):
                         url = k
                         break


### PR DESCRIPTION
In python3, if the list being iterated over changes during the
iteration, an exception is thrown. This patch avoids this by
turning the iterable into a list.