### PR TITLE
Remove pyrsistent dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     install_requires=["requests",
                       "websocket-client>0.33.0",
                       "jsonschema",
-                      "pyrsistent<=0.16.0",
                       "six"],
     tests_requires=["mock"],
     description="This library allows basic Cisco ACI APIC configuration.",


### PR DESCRIPTION
Commit f70187f13ea7b27e6f2767943bcc1ca20590dc12 add the dependency
on pyrsistent. This dependency isn't needed, so this patch removes it.